### PR TITLE
avoid keywords. compilation with VS2019

### DIFF
--- a/include/xtl/xtype_traits.hpp
+++ b/include/xtl/xtype_traits.hpp
@@ -322,7 +322,7 @@ namespace xtl
 #if !defined(__GNUC__) || (defined(__GNUC__) && (__GNUC__ >= 5))
 
     template <class... C>
-    constexpr bool requires = conjunction<C...>::value;
+    constexpr bool xtl_requires = conjunction<C...>::value;
 
     template <class... C>
     constexpr bool either = disjunction<C...>::value;
@@ -334,7 +334,7 @@ namespace xtl
     constexpr bool disallow_one = xtl::negation<xtl::disjunction<C...>>::value;
 
     template <class... C>
-    using check_requires = std::enable_if_t<requires<C...>, int>;
+    using check_requires = std::enable_if_t<xtl_requires<C...>, int>;
 
     template <class... C>
     using check_either = std::enable_if_t<either<C...>, int>;


### PR DESCRIPTION
look like requires is a keyword in VS2019 C++ and this names give hundreds errors.