### PR TITLE
[WIP] Compile to WebAssembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ docs/build/
 
 # Generated files
 *.pc
+
+# JavaScript files
+node_modules
+js/lib
+*.wasm

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ make html
 
 from the `docs` subdirectory.
 
+## Compiling to WebAssembly
+
+A subset of the library has been compiled to WebAssembly so it can be used in a web browser.
+
+Refer to the [instructions](./js/README.md) for more information.
+
 ## License
 
 We use a shared copyright model that enables all contributors to maintain the

--- a/js/README.md
+++ b/js/README.md
@@ -1,0 +1,19 @@
+# xtl.js
+
+A port of the `xtl` library to WebAssembly.
+
+List of currently supported tools and functions:
+
+- `murmur2_x86`
+
+
+## Setup
+
+```bash
+conda install -c conda-forge python=3 cmake openjdk
+
+# TODO: setup emsdk
+
+source /path/to/emsdk/emsk_env.sh
+
+```

--- a/js/build.sh
+++ b/js/build.sh
@@ -1,0 +1,1 @@
+em++ ./main.cpp -O2 --bind -std=c++11 -s WASM=1 -o ./lib/xtl.js

--- a/js/main.cpp
+++ b/js/main.cpp
@@ -1,0 +1,13 @@
+#include <emscripten/bind.h>
+
+#include "../include/xtl/xhash.hpp"
+
+using namespace emscripten;
+
+uint32_t murmur2(const std::string& content, uint32_t seed) {
+    return xtl::murmur2_x86(content.data(), content.size(), seed);
+}
+
+EMSCRIPTEN_BINDINGS(my_module) {
+    function("murmur2", &murmur2);
+}

--- a/js/package.json
+++ b/js/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "xtl",
+  "version": "0.1.0",
+  "description": "XTL port to WebAssembly",
+  "main": "lib/xtl.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/xtensor-stack/xtl.git"
+  },
+  "keywords": [
+    "xtl",
+    "wasm"
+  ],
+  "files": [
+    "lib/**/*.d.ts",
+    "lib/**/*.js.map",
+    "lib/**/*.js",
+    "lib/**/*.wasm"
+  ],
+  "author": "QuantStack",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/xtensor-stack/xtl/issues"
+  },
+  "homepage": "https://github.com/xtensor-stack/xtl#readme"
+}

--- a/js/test.js
+++ b/js/test.js
@@ -1,0 +1,4 @@
+const xtl = require('.');
+const str = 'abcdef';
+
+console.log(xtl.murmur2(str, 42));


### PR DESCRIPTION
Compile a subset to WebAssembly so the library can be used in a web browser.

As an example, this will make it possible to reuse the same implementation of the `murmur2_x86` function in different environments.

I am not sure yet if it makes sense to compile the whole `xtl` to WebAssembly. But a subset could still be useful.

### Current status

This seems to work from a node REPL:

![node-wasm](https://user-images.githubusercontent.com/591645/68431863-8035ba80-01b3-11ea-8ea5-1e416603e4f3.gif)

### TODO

- [x] Glue code with `EMSCRIPTEN_BINDINGS`
- [x] Add *.wasm to gitignore
- [ ] Add instructions for a local `emsdk` setup, or build in Docker, or use the existing `cmake` config
- [ ] Handle async loading
- [ ] Use with webpack
- [ ] Use in a JupyterLab extension
- [ ] Build on CI
- [ ] Release `xtl.js` version `0.1.0` to npm

