### PR TITLE
now works with nvcc compiler

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,11 @@
 Changelog
 =========
 
+0.6.12
+------
+
+- NVCC CUDA compiler compatibility
+
 0.6.11
 ------
 

--- a/include/xtl/xsequence.hpp
+++ b/include/xtl/xsequence.hpp
@@ -134,7 +134,8 @@ namespace xtl
         };
         
         template <class R, class A>
-        struct sequence_forwarder_impl<R, A, void_t<decltype(std::declval<R>().resize(std::size_t()))>>
+        struct sequence_forwarder_impl<R, A, void_t<decltype(std::declval<R>().resize(
+              std::declval<std::size_t>()))>>
         {
             template <class T>
             static inline auto forward(const T& r)

--- a/include/xtl/xvariant_impl.hpp
+++ b/include/xtl/xvariant_impl.hpp
@@ -2660,20 +2660,20 @@ namespace mpark {
 #ifdef MPARK_CPP14_CONSTEXPR
   namespace detail {
 
-    inline constexpr bool all(std::initializer_list<bool> bs) {
+    inline constexpr bool any(std::initializer_list<bool> bs) {
       for (bool b : bs) {
-        if (!b) {
-          return false;
+        if (b) {
+          return true;
         }
       }
-      return true;
+      return false;
     }
 
   }  // namespace detail
 
   template <typename Visitor, typename... Vs>
   inline constexpr decltype(auto) visit(Visitor &&visitor, Vs &&... vs) {
-    return (detail::all({!vs.valueless_by_exception()...})
+    return (!detail::any({vs.valueless_by_exception()...})
                 ? (void)0
                 : throw_bad_variant_access()),
            detail::visitation::variant::visit_value(

--- a/include/xtl/xvariant_impl.hpp
+++ b/include/xtl/xvariant_impl.hpp
@@ -2660,20 +2660,20 @@ namespace mpark {
 #ifdef MPARK_CPP14_CONSTEXPR
   namespace detail {
 
-    inline constexpr bool any(std::initializer_list<bool> bs) {
+    inline constexpr bool all(std::initializer_list<bool> bs) {
       for (bool b : bs) {
-        if (b) {
-          return true;
+        if (!b) {
+          return false;
         }
       }
-      return false;
+      return true;
     }
 
   }  // namespace detail
 
   template <typename Visitor, typename... Vs>
   inline constexpr decltype(auto) visit(Visitor &&visitor, Vs &&... vs) {
-    return (!detail::any({vs.valueless_by_exception()...})
+    return (detail::all({!vs.valueless_by_exception()...})
                 ? (void)0
                 : throw_bad_variant_access()),
            detail::visitation::variant::visit_value(


### PR DESCRIPTION
This solves issue #183 and allows XTL to be used with host-side CUDA code. Previously, the nvcc compiler failed to correctly parse two LOC in XTL, and these expressions have been modified to something more friendly for nvcc. As a result of this, xtensor now also works with host-side CUDA!

I think adding a separate test for the nvcc compiler may not make sense at this point though.

Also... I hope I understood the rule on modifying the changelog correctly. Does each PR modify the changelog?