### PR TITLE
mpark/variant small change for CUDA 10.2 workaround

### DIFF
--- a/include/xtl/xvariant_impl.hpp
+++ b/include/xtl/xvariant_impl.hpp
@@ -2660,20 +2660,20 @@ namespace mpark {
 #ifdef MPARK_CPP14_CONSTEXPR
   namespace detail {
 
-    inline constexpr bool all(std::initializer_list<bool> bs) {
+    inline constexpr bool any(std::initializer_list<bool> bs) {
       for (bool b : bs) {
-        if (!b) {
-          return false;
+        if (b) {
+          return true;
         }
       }
-      return true;
+      return false;
     }
 
   }  // namespace detail
 
   template <typename Visitor, typename... Vs>
   inline constexpr decltype(auto) visit(Visitor &&visitor, Vs &&... vs) {
-    return (detail::all({!vs.valueless_by_exception()...})
+    return (!detail::any({vs.valueless_by_exception()...})
                 ? (void)0
                 : throw_bad_variant_access()),
            detail::visitation::variant::visit_value(


### PR DESCRIPTION
Discussed in issue #183 

In short, CUDA 10.2 fails to parse this one not sign in front of a parameter pack expansion.
