### PR TITLE
Unconstraint nlohmann_json version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
             - g++-9
       env: COMPILER=gcc GCC=9
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode9
       compiler: clang
 env:
   global:

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - cmake
-  - nlohmann_json<3.8
+  - nlohmann_json


### PR DESCRIPTION
It seems that things broke with nlohmann_json 3.8 on OS X.

Trying to un-constraint things.