### PR TITLE
Add support for xtl:endianness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(XTL_HEADERS
     ${XTL_INCLUDE_DIR}/xtl/xoptional_meta.hpp
     ${XTL_INCLUDE_DIR}/xtl/xoptional.hpp
     ${XTL_INCLUDE_DIR}/xtl/xoptional_sequence.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xplatform.hpp
     ${XTL_INCLUDE_DIR}/xtl/xproxy_wrapper.hpp
     ${XTL_INCLUDE_DIR}/xtl/xsequence.hpp
     ${XTL_INCLUDE_DIR}/xtl/xtl_config.hpp

--- a/include/xtl/xplatform.hpp
+++ b/include/xtl/xplatform.hpp
@@ -1,0 +1,39 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTL_XPLATFORM_HPP
+#define XTL_XPLATFORM_HPP
+
+#include <cstring>
+#include <cstdint>
+
+namespace xtl
+{
+  enum class endian {
+    big_endian,
+    little_endian,
+    mixed,
+  };
+
+  inline endian endianness() {
+    uint32_t utmp = 0x01020304;
+    char btmp[sizeof(utmp)];
+    std::memcpy(&btmp[0], &utmp, sizeof(utmp));
+    switch(btmp[0]) {
+      case 0x01:
+        return endian::big_endian;
+      case 0x04:
+        return endian::little_endian;
+      default:
+        return endian::mixed;
+    }
+  }
+}
+
+#endif

--- a/include/xtl/xplatform.hpp
+++ b/include/xtl/xplatform.hpp
@@ -15,25 +15,28 @@
 
 namespace xtl
 {
-  enum class endian {
-    big_endian,
-    little_endian,
-    mixed,
-  };
+    enum class endian
+    {
+        big_endian,
+        little_endian,
+        mixed
+    };
 
-  inline endian endianness() {
-    uint32_t utmp = 0x01020304;
-    char btmp[sizeof(utmp)];
-    std::memcpy(&btmp[0], &utmp, sizeof(utmp));
-    switch(btmp[0]) {
-      case 0x01:
-        return endian::big_endian;
-      case 0x04:
-        return endian::little_endian;
-      default:
-        return endian::mixed;
+    inline endian endianness()
+    {
+        uint32_t utmp = 0x01020304;
+        char btmp[sizeof(utmp)];
+        std::memcpy(&btmp[0], &utmp, sizeof(utmp));
+        switch(btmp[0])
+        {
+        case 0x01:
+            return endian::big_endian;
+        case 0x04:
+            return endian::little_endian;
+        default:
+            return endian::mixed;
+        }
     }
-  }
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -117,12 +117,6 @@ endif()
 
 find_package(Threads)
 
-include(TestBigEndian)
-TEST_BIG_ENDIAN(BIG_ENDIAN)
-if(BIG_ENDIAN)
-    add_definitions(-DSYSTEM_IS_BIG_ENDIAN)
-endif(BIG_ENDIAN)
-
 include_directories(${GTEST_INCLUDE_DIRS})
 
 set(XTL_TESTS
@@ -143,6 +137,7 @@ set(XTL_TESTS
     test_xoptional.cpp
     test_xsequence.cpp
     test_xtype_traits.cpp
+    test_xplatform.cpp
     test_xproxy_wrapper.cpp
     test_xvariant.cpp
     test_xvisitor.cpp

--- a/test/test_xhash.cpp
+++ b/test/test_xhash.cpp
@@ -8,6 +8,7 @@
 ****************************************************************************/
 
 #include "xtl/xhash.hpp"
+#include "xtl/xplatform.hpp"
 
 #include <cstdint>
 #include <cstdlib>
@@ -147,11 +148,17 @@ namespace xtl
     TEST(hash, verification)
     {
 #if INTPTR_MAX == INT64_MAX
-#if SYSTEM_IS_BIG_ENDIAN
-        uint32_t res = 0x8fda498d;
-#else
-        uint32_t res = sizeof(std::size_t) == 4 ? 0x27864c1e : 0x1f0d3804;
-#endif
+      uint32_t res;
+      switch(endianness()) {
+        case endian::big_endian:
+          res = 0x8fda498d;
+          break;
+        case endian::little_endian:
+          res = sizeof(std::size_t) == 4 ? 0x27864c1e : 0x1f0d3804;
+          break;
+        default:
+          assert(false && "unsupported exotic architecture");
+      }
 #elif INTPTR_MAX == INT32_MAX
         uint32_t res = sizeof(std::size_t) == 4 ? 0x27864c1e : 0xdd537c05;
 #else

--- a/test/test_xplatform.cpp
+++ b/test/test_xplatform.cpp
@@ -1,0 +1,29 @@
+/***************************************************************************
+* Copyright (c) Johan Mabille, Sylvain Corlay and Wolf Vollprecht          *
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "xtl/xplatform.hpp"
+
+
+#include "gtest/gtest.h"
+
+namespace xtl
+{
+
+    TEST(platform, endian)
+    {
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
+        EXPECT_TRUE(endianness() == endian::big_endian);
+#endif
+
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN
+        EXPECT_TRUE(endianness() == endian::little_endian);
+#endif
+    }
+}
+


### PR DESCRIPTION
This tests at runtime whether the target platform is little, big or mixed endian.
It also replace the configuration-time check that previously existed, just for
the sake of testing.

Note that C++20 proposes std::endian as well as a constexpr std::bit_cast, but
we're not there yet.

And even if a set of macro checks could replace that runtime check, it's much
more portable and maintainable to do it that way, esp. as both gcc and clang
actually fold that function.

# Checklist

- The title and the commit message(s) are descriptive
- Small commits made to fix your PR have been squashed to avoid history pollution
- Tests have been added for new features or bug fixes
- API of new functions and classes are documented

# Description
