### PR TITLE
Complex promote type with different base types

### DIFF
--- a/include/xtl/xtype_traits.hpp
+++ b/include/xtl/xtype_traits.hpp
@@ -130,6 +130,12 @@ namespace xtl
         using type = std::complex<T>;
     };
 
+    template <class T1, class T2>
+    struct promote_type<std::complex<T1>, std::complex<T2>>
+    {
+        using type = std::complex<typename promote_type<T1, T2>::type>;
+    };
+
     template <class... REST>
     struct promote_type<bool, REST...>
     {

--- a/test/test_xtype_traits.cpp
+++ b/test/test_xtype_traits.cpp
@@ -137,6 +137,7 @@ namespace xtl
         EXPECT_TRUE((std::is_same<time_type, promote_type_t<time_type, time_type>>::value));
         EXPECT_TRUE((std::is_same<int, promote_type_t<unsigned char, unsigned char>>::value));
         EXPECT_TRUE((std::is_same<std::complex<double>, promote_type_t<unsigned char, std::complex<double>>>::value));
+        EXPECT_TRUE((std::is_same<std::complex<double>, promote_type_t<std::complex<float>, std::complex<double>>>::value));
     }
 }
 


### PR DESCRIPTION
# Checklist

- [x] The title and the commit message(s) are descriptive
- [x] Small commits made to fix your PR have been squashed to avoid history pollution
- [x] Tests have been added for new features or bug fixes
- [x] API of new functions and classes are documented

# Description

The abbreviation `promote_type_t` is currently not working with 2 complex types using different base types (e.g. `complex<float>` and `complex<double>`) due to ambiguous resolution. The templated struct `promote_type` needs a better match.

This PR implements a template specialization and a unit test.