### PR TITLE
test/test_xsystem.cpp: Allow for ctest executable names

### DIFF
--- a/test/test_xsystem.cpp
+++ b/test/test_xsystem.cpp
@@ -26,7 +26,6 @@ namespace xtl
 
         EXPECT_NE(prefix.size(), exec_path.size());
         EXPECT_TRUE(std::equal(prefix.cbegin(), prefix.cend(), exec_path.cbegin()));
-        EXPECT_NE(exec_path.find("test_xtl"), std::string::npos);
+        EXPECT_TRUE((exec_path.find("test_xtl") != std::string::npos) || (exec_path.find("test_xsystem") != std::string::npos));
     }
 }
-


### PR DESCRIPTION
# Description

This PR fixes a very minor issue: The test executables are not called "test_xtl" for us, possibly because we execute `ctest` directly. This PR adds both executable names.