### PR TITLE
Fixed return type in xbasic_fixed_string to be compatible with C++11

### DIFF
--- a/include/xtl/xbasic_fixed_string.hpp
+++ b/include/xtl/xbasic_fixed_string.hpp
@@ -87,12 +87,12 @@ namespace xtl
                 m_buffer[N - 1] = N - size;
             }
 
-            auto& buffer()
+            T* buffer()
             {
                 return m_buffer;
             }
 
-            auto const & buffer() const
+            const T* buffer() const
             {
                 return m_buffer;
             }


### PR DESCRIPTION
# Checklist

- The title and the commit message(s) are descriptive
- Small commits made to fix your PR have been squashed to avoid history pollution
- Tests have been added for new features or bug fixes
- API of new functions and classes are documented

# Description
