### PR TITLE
Fix error: lvalue required as unary '&' operand

### DIFF
--- a/test/test_xvariant.cpp
+++ b/test/test_xvariant.cpp
@@ -164,27 +164,27 @@ namespace xtl
     TEST(xvariant, const_closure_wrapper)
     {
         {
-            const int i = 2;
+            static const int i = 2;
             variant_cref v = closure(i);
             const int& cir = xtl::xget<const int&>(v);
             EXPECT_EQ(&cir, &i);
         }
 
         {
-            const int i = 2;
+            static const int i = 2;
             const variant_cref v = closure(i);
             const int& cir = xtl::xget<const int&>(v);
             EXPECT_EQ(&cir, &i);
         }
 
         {
-            const int i = 2;
+            static const int i = 2;
             const int& cir = xtl::xget<const int&>(build_test_variant(i));
             EXPECT_EQ(&cir, &i);
         }
 
         {
-            const int i = 2;
+            static const int i = 2;
             const int& cir = xtl::xget<const int&>(build_test_cvariant(i));
             EXPECT_EQ(&cir, &i);
         }


### PR DESCRIPTION
`const` variable could be inlined so maybe no address for it. Make it `static` for getting address.

Error reported on GCC4.9.4