### PR TITLE
adding is_arithmetic, is_floating, etc. traits to xmasked_value.

### DIFF
--- a/include/xtl/xmasked_value.hpp
+++ b/include/xtl/xmasked_value.hpp
@@ -541,6 +541,28 @@ namespace xtl
 #undef DEFINE_UNARY_BOOL_OPERATOR
 #undef DEFINE_OPERATOR
 #undef DEFINE_BOOL_OPERATOR
+
+
+    template <class T, class B>
+    struct is_scalar<xmasked_value<T, B>> : is_scalar<std::remove_reference_t<T>>
+    {
+    };
+
+    template <class T, class B>
+    struct is_arithmetic<xmasked_value<T, B>> : is_arithmetic<std::remove_reference_t<T>>
+    {
+    };
+
+    template <class T, class B>
+    struct is_signed<xmasked_value<T, B>> : is_signed<std::remove_reference_t<T>>
+    {
+    };
+
+    template <class T, class B>
+    struct is_floating_point<xmasked_value<T, B>> : is_floating_point<std::remove_reference_t<T>>
+    {
+    };
+
 }
 
 #endif


### PR DESCRIPTION
This fixes a bug in xtensor, when assigning to xmasked_view with `xt::noalias` wouldn't compile:
```cpp
xarray<double> data = {{ 1.,-2., 3.},
                        { 4., 5.,-6.},
                        { 7., 8.,-9.}};
xarray<double> data2 = {{ 0.1, 0.2, 0.3},
                        { 0.4, 0.5, 0.6},
                        { 0.7, 0.8, 0.9}};
xarray<bool> mask = {{ true,  true,  true},
                     { true, false, false},
                     { true, false,  true}};

auto masked_data = masked_view(data, mask);

xt::noalias(masked_data) = data2; // compile error
```
<details>
<summary>Error log:</summary>

```cpp
[build] In file included from /home/path_to_xtensor/xtensor/test/test_xmasked_view.cpp:13:
[build] In file included from /home/path_to_xtensor/xtensor/include/xtensor/xmasked_view.hpp:13:
[build] /data/build_dir/Debug/include/xtl/xmasked_value.hpp:123:11: error: binding reference of type 'double' to value of type 'const double' drops 'const' qualifier
[build]         : m_value(std::forward<T1>(value)), m_visible(true)
[build]           ^       ~~~~~~~~~~~~~~~~~~~~~~~
[build] /home/path_to_xtensor/xtensor/include/xtensor/xutils.hpp:714:20: note: in instantiation of function template specialization 'xtl::xmasked_value<double &, bool &>::xmasked_value<const double &>' requested here
[build]             return static_cast<T>(std::forward<U>(u));
[build]                    ^
[build] /home/path_to_xtensor/xtensor/include/xtensor/xutils.hpp:729:16: note: in instantiation of function template specialization 'xt::conditional_cast_functor<true, xtl::xmasked_value<double &, bool &>>::operator()<const double &>' requested here
[build]         return conditional_cast_functor<condition, T>()(std::forward<U>(u));
[build]                ^
[build] /home/path_to_xtensor/xtensor/include/xtensor/xassign.hpp:582:22: note: in instantiation of function template specialization 'xt::conditional_cast<true, xtl::xmasked_value<double &, bool &>, const double &>' requested here
[build]             *m_lhs = conditional_cast<needs_cast, result_type>(*m_rhs);
[build]                      ^
[build] /home/path_to_xtensor/xtensor/include/xtensor/xassign.hpp:405:22: note: in instantiation of member function 'xt::stepper_assigner<xt::xmasked_view<xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::xarray_container<xt::uvector<bool, xsimd::aligned_allocator<bool, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &>, xt::xbroadcast<const xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>>, xt::layout_type::row_major>::run' requested here
[build]             assigner.run();
[build]                      ^
[build] /home/path_to_xtensor/xtensor/include/xtensor/xassign.hpp:193:36: note: in instantiation of function template specialization 'xt::xexpression_assigner_base<xt::xtensor_expression_tag>::assign_data<xt::xmasked_view<xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::xarray_container<xt::uvector<bool, xsimd::aligned_allocator<bool, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &>, xt::xbroadcast<const xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>>>' requested here
[build]         xexpression_assigner<tag>::assign_data(e1, e2, trivial);
[build]                                    ^
[build] /home/path_to_xtensor/xtensor/include/xtensor/xsemantic.hpp:913:13: note: in instantiation of function template specialization 'xt::assign_data<xt::xmasked_view<xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::xarray_container<xt::uvector<bool, xsimd::aligned_allocator<bool, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &>, xt::xbroadcast<const xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>>>' requested here
[build]         xt::assign_data(*this, e, detail::get_rhs_triviality(e.derived_cast()));
[build]             ^
[build] /home/path_to_xtensor/xtensor/include/xtensor/xsemantic.hpp:705:37: note: in instantiation of function template specialization 'xt::xview_semantic<xt::xmasked_view<xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::xarray_container<xt::uvector<bool, xsimd::aligned_allocator<bool, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &>>::assign_xexpression<xt::xbroadcast<const xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>>>' requested here
[build]         return this->derived_cast().assign_xexpression(e);
[build]                                     ^
[build] /home/path_to_xtensor/xtensor/include/xtensor/xsemantic.hpp:822:26: note: in instantiation of function template specialization 'xt::xsemantic_base<xt::xmasked_view<xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::xarray_container<xt::uvector<bool, xsimd::aligned_allocator<bool, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &>>::assign<xt::xbroadcast<const xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>>>' requested here
[build]             return this->assign(e);
[build]                          ^
[build] /home/path_to_xtensor/xtensor/include/xtensor/xsemantic.hpp:968:24: note: in instantiation of function template specialization 'xt::xsemantic_base<xt::xmasked_view<xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::xarray_container<xt::uvector<bool, xsimd::aligned_allocator<bool, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &>>::operator=<xt::xbroadcast<const xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>>>' requested here
[build]             base_type::operator=(broadcast(rhs.derived_cast(), this->derived_cast().shape()));
[build]                        ^
[build] /home/path_to_xtensor/xtensor/include/xtensor/xmasked_view.hpp:583:31: note: in instantiation of function template specialization 'xt::xview_semantic<xt::xmasked_view<xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::xarray_container<xt::uvector<bool, xsimd::aligned_allocator<bool, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &>>::operator=<xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>>>' requested here
[build]         return semantic_base::operator=(e);
[build]                               ^
[build] /home/path_to_xtensor/xtensor/test/test_xmasked_view.cpp:239:21: note: in instantiation of function template specialization 'xt::xmasked_view<xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &, xt::xarray_container<xt::uvector<bool, xsimd::aligned_allocator<bool, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>> &>::operator=<xt::xarray_container<xt::uvector<double, xsimd::aligned_allocator<double, 32>>, xt::layout_type::row_major, xt::svector<unsigned long, 4, std::allocator<unsigned long>, true>>>' requested here
[build]         masked_data = data2;
[build]                     ^
```

</details>
