### PR TITLE
Add <compare> backport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(XTL_HEADERS
     ${XTL_INCLUDE_DIR}/xtl/xbasic_fixed_string.hpp
     ${XTL_INCLUDE_DIR}/xtl/xbase64.hpp
     ${XTL_INCLUDE_DIR}/xtl/xclosure.hpp
+    ${XTL_INCLUDE_DIR}/xtl/xcompare.hpp
     ${XTL_INCLUDE_DIR}/xtl/xcomplex.hpp
     ${XTL_INCLUDE_DIR}/xtl/xcomplex_sequence.hpp
     ${XTL_INCLUDE_DIR}/xtl/xspan.hpp

--- a/docs/source/miscellaneous.rst
+++ b/docs/source/miscellaneous.rst
@@ -22,3 +22,11 @@ endianness
 
 TODO
 
+Comparison
+----------
+
+.. cpp:namespace-push:: xt
+
+.. doxygengroup:: xtl_xcompare
+
+.. cpp:namespace-pop::

--- a/include/xtl/xcompare.hpp
+++ b/include/xtl/xcompare.hpp
@@ -1,0 +1,179 @@
+/***************************************************************************
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#ifndef XTL_COMPARE_HPP
+#define XTL_COMPARE_HPP
+
+#include <type_traits>
+
+namespace xtl
+{
+
+    /**
+     * @defgroup xtl_xcompare
+     *
+     * Compare the values of two integers t and u. Unlike builtin comparison operators,
+     * negative signed integers always compare less than (and not equal to) unsigned integers.
+     */
+
+    namespace detail
+    {
+        template <class T, class U>
+        struct same_signedness :
+           std::integral_constant<bool, std::is_signed<T>::value == std::is_signed<U>::value>
+        {
+        };
+
+        template <
+            class T,
+            class U,
+            std::enable_if_t<same_signedness<T, U>::value, bool> = true
+        >
+        constexpr bool cmp_equal_impl(T t, U u) noexcept
+        {
+            return t == u;
+        }
+
+        template <
+            class T,
+            class U,
+            std::enable_if_t<
+                !same_signedness<T, U>::value && std::is_signed<T>::value,
+                bool
+            > = true
+        >
+        constexpr bool cmp_equal_impl(T t, U u) noexcept
+        {
+            using UT = std::make_unsigned_t<T>;
+            return t < 0 ? false : static_cast<UT>(t) == u;
+        }
+
+        template <
+            class T,
+            class U,
+            std::enable_if_t<
+                !same_signedness<T, U>::value && !std::is_signed<T>::value,
+                bool
+            > = true
+        >
+        constexpr bool cmp_equal_impl(T t, U u) noexcept
+        {
+            using UU = std::make_unsigned_t<U>;
+            return u < 0 ? false : t == static_cast<UU>(u);
+        }
+    }
+
+    /**
+     * ``true`` if @p t is equal to @p u.
+     *
+     * @ingroup xtl_xcompare
+     */
+    template <class T, class U>
+    constexpr bool cmp_equal(T t, U u) noexcept
+    {
+        return detail::cmp_equal_impl(t, u);
+    }
+
+    /**
+     * ``true`` if @p t is not equal to @p u.
+     *
+     * @ingroup xtl_xcompare
+     */
+    template <class T, class U>
+    constexpr bool cmp_not_equal(T t, U u) noexcept
+    {
+        return !cmp_equal(t, u);
+    }
+
+    namespace detail
+    {
+        template <
+            class T,
+            class U,
+            std::enable_if_t<detail::same_signedness<T, U>::value, bool> = true
+        >
+        constexpr bool cmp_less_impl(T t, U u) noexcept
+        {
+            return t < u;
+        }
+
+        template <
+            class T,
+            class U,
+            std::enable_if_t<
+                !detail::same_signedness<T, U>::value && std::is_signed<T>::value,
+                bool
+            > = true
+        >
+        constexpr bool cmp_less_impl(T t, U u) noexcept
+        {
+            using UT = std::make_unsigned_t<T>;
+            return t < 0 ? true : static_cast<UT>(t) < u;
+        }
+
+        template <
+            class T,
+            class U,
+            std::enable_if_t<
+                !detail::same_signedness<T, U>::value && !std::is_signed<T>::value,
+                bool
+            > = true
+        >
+        constexpr bool cmp_less_impl(T t, U u) noexcept
+        {
+            using UU = std::make_unsigned_t<U>;
+            return u < 0 ? false : t < static_cast<UU>(u);
+        }
+    }
+
+    /**
+     * ``true`` if @p t is striclty less than @p u.
+     *
+     * @ingroup xtl_xcompare
+     */
+    template <class T, class U>
+    constexpr bool cmp_less(T t, U u) noexcept
+    {
+        return detail::cmp_less_impl(t, u);
+    }
+
+    /**
+     * ``true`` if @p t is striclty greater than @p u.
+     *
+     * @ingroup xtl_xcompare
+     */
+    template <class T, class U>
+    constexpr bool cmp_greater(T t, U u) noexcept
+    {
+        return cmp_less(u, t);
+    }
+
+    /**
+     * ``true`` if @p t is less or equal to @p u.
+     *
+     * @ingroup xtl_xcompare
+     */
+    template <class T, class U>
+    constexpr bool cmp_less_equal(T t, U u) noexcept
+    {
+        return !cmp_greater(t, u);
+    }
+
+    /**
+     * ``true`` if @p t is greater or equal to @p u.
+     *
+     * @ingroup xtl_xcompare
+     */
+    template <class T, class U>
+    constexpr bool cmp_greater_equal(T t, U u) noexcept
+    {
+        return !cmp_less(t, u);
+    }
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,6 +87,7 @@ set(XTL_TESTS
     test_xbase64.cpp
     test_xbasic_fixed_string.cpp
     test_xcomplex.cpp
+    test_xcompare.cpp
     test_xcomplex_sequence.cpp
     test_xclosure.cpp
     test_xdynamic_bitset.cpp

--- a/test/test_xcompare.cpp
+++ b/test/test_xcompare.cpp
@@ -1,0 +1,41 @@
+/***************************************************************************
+* Copyright (c) QuantStack                                                 *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include "xtl/xcompare.hpp"
+
+#include "test_common_macros.hpp"
+
+namespace xtl
+{
+    TEST(xcompare, cmp_equal)
+    {
+        EXPECT_TRUE(cmp_equal(0, 0));
+        EXPECT_TRUE(cmp_equal(1ul, 1ul));
+        EXPECT_TRUE(cmp_equal(1, 1ul));
+        EXPECT_TRUE(cmp_equal(1ul, 1));
+        EXPECT_TRUE(cmp_equal(-1, -1));
+
+        EXPECT_FALSE(cmp_equal(0, 1));
+        EXPECT_FALSE(cmp_equal(-1, 1ul));
+        EXPECT_FALSE(cmp_equal(0ul, 1ul));
+    }
+
+    TEST(xcompare, cmp_less)
+    {
+        EXPECT_FALSE(cmp_less(0, 0));
+        EXPECT_FALSE(cmp_less(1ul, 1ul));
+        EXPECT_FALSE(cmp_less(1, 1ul));
+        EXPECT_FALSE(cmp_less(1ul, 1));
+        EXPECT_FALSE(cmp_less(-1, -1));
+
+        EXPECT_TRUE(cmp_less(1, 2));
+        EXPECT_TRUE(cmp_less(-2, -1));
+        EXPECT_TRUE(cmp_less(-2, 1));
+        EXPECT_FALSE(cmp_less(1, -1));
+    }
+}


### PR DESCRIPTION
# Checklist

- [x] The title and the commit message(s) are descriptive
- [x] Small commits made to fix your PR have been squashed to avoid history pollution
- [x] Tests have been added for new features or bug fixes
- [x] API of new functions and classes are documented

# Description
A backport of the C++20 <compare>  header for integer comparison.
