### PR TITLE
Add missing #include <exception>

### DIFF
--- a/include/xtl/xany.hpp
+++ b/include/xtl/xany.hpp
@@ -10,6 +10,7 @@
 #ifndef XTL_ANY_HPP
 #define XTL_ANY_HPP
 
+#include <exception>
 #include <stdexcept>
 #include <type_traits>
 #include <typeinfo>

--- a/include/xtl/xbasic_fixed_string.hpp
+++ b/include/xtl/xbasic_fixed_string.hpp
@@ -11,6 +11,7 @@
 #define XTL_BASIC_FIXED_STRING_HPP
 
 #include <cstddef>
+#include <exception>
 #include <functional>
 #include <iterator>
 #include <sstream>

--- a/include/xtl/xspan_impl.hpp
+++ b/include/xtl/xspan_impl.hpp
@@ -16,6 +16,7 @@ http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0122r7.pdf
 
 #include <array>
 #include <cstddef>
+#include <exception>
 #include <type_traits>
 
 #ifndef TCB_SPAN_NO_EXCEPTIONS


### PR DESCRIPTION
This is necessary to make code compile with a recent libc++ (after https://reviews.llvm.org/D146097).
