### PR TITLE
Fix promote_type with two complex floats and one double

### DIFF
--- a/include/xtl/xtype_traits.hpp
+++ b/include/xtl/xtype_traits.hpp
@@ -36,17 +36,17 @@ namespace xtl
     struct is_fundamental : std::is_fundamental<T>
     {
     };
-    
+
     template <class T>
     struct is_signed : std::is_signed<T>
     {
     };
-    
+
     template <class T>
     struct is_floating_point : std::is_floating_point<T>
     {
     };
-    
+
     template <class T>
     struct is_integral : std::is_integral<T>
     {
@@ -86,12 +86,6 @@ namespace xtl
     struct promote_type<T0, T1>
     {
         using type = decltype(std::declval<std::decay_t<T0>>() + std::declval<std::decay_t<T1>>());
-    };
-
-    template <class T0, class... REST>
-    struct promote_type<T0, REST...>
-    {
-        using type = decltype(std::declval<std::decay_t<T0>>() + std::declval<typename promote_type<REST...>::type>());
     };
 
     template <>
@@ -136,10 +130,10 @@ namespace xtl
         using type = std::complex<typename promote_type<T1, T2>::type>;
     };
 
-    template <class... REST>
-    struct promote_type<bool, REST...>
+    template <class T, class... REST>
+    struct promote_type<T, REST...>
     {
-        using type = typename promote_type<bool, typename promote_type<REST...>::type>::type;
+        using type = typename promote_type<T, typename promote_type<REST...>::type>::type;
     };
 
     /**

--- a/test/test_xtype_traits.cpp
+++ b/test/test_xtype_traits.cpp
@@ -138,6 +138,6 @@ namespace xtl
         EXPECT_TRUE((std::is_same<int, promote_type_t<unsigned char, unsigned char>>::value));
         EXPECT_TRUE((std::is_same<std::complex<double>, promote_type_t<unsigned char, std::complex<double>>>::value));
         EXPECT_TRUE((std::is_same<std::complex<double>, promote_type_t<std::complex<float>, std::complex<double>>>::value));
+        EXPECT_TRUE((std::is_same<std::complex<double>, promote_type_t<std::complex<float>, std::complex<float>, double>>::value));
     }
 }
-


### PR DESCRIPTION
While using `xt::allclose` on two objects containing `std::complex<float>`, I got an error from `xtl::promote_type<std::complex<float>, std::complex<float>, double>` that it tried determining the type when adding a `std::complex<float>` to a `std::complex<double>`, which is not defined.

When evaluating `xtl::promote_type<std::complex<float>, std::complex<float>, double>`, xtl indeed first recursively evaluates `xtl::promote_type<std::complex<float>, double>`, which yields a `std::complex<double>`. Then it determines the type of adding `std::complex<float>` and `std::complex<double>` using `decltype` and `declval`, which fails.

This fix avoids the addition operator in recursive calls of the `promote_type` template by generalizing the existing recursive template that already uses a `bool` as a first argument.

I also added a test that fails to compile without the fix and works fine with the fix.

I see that my editor removed some spaces and a final newline. Please let me know if that's a problem.