### PR TITLE
test/CMakeLists.txt: remove extra find_package(Threads)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,6 @@
 cmake_minimum_required(VERSION 3.1)
 
 find_package(doctest            REQUIRED)
-find_package(Threads)
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xtl-test)


### PR DESCRIPTION
The directive is also present later. The earlier occurrence makes compilation fail with the following error:

```
CMake Error at /usr/share/cmake-3.27/Modules/FindThreads.cmake:66 (message):
  FindThreads only works if either C or CXX language is enabled
Call Stack (most recent call first):
  CMakeLists.txt:13 (find_package)
```