### PR TITLE
Use GetModuleFileNameW for wchar_t array

### DIFF
--- a/include/xtl/xsystem.hpp
+++ b/include/xtl/xsystem.hpp
@@ -49,7 +49,11 @@ namespace xtl
     inline std::string executable_path()
     {
         std::string path;
-        char buffer[1024];
+#if defined(UNICODE)
+    wchar_t buffer[1024];
+#else
+    char buffer[1024];
+#endif
         std::memset(buffer, '\0', sizeof(buffer));
 #if defined(__linux__)
         if (readlink("/proc/self/exe", buffer, sizeof(buffer)) != -1)
@@ -61,14 +65,21 @@ namespace xtl
             // failed to determine run path
         }
 #elif defined (_WIN32)
-        if (GetModuleFileName(nullptr, buffer, sizeof(buffer)) != 0)
+    #if defined(UNICODE)
+        if (GetModuleFileNameW(nullptr, buffer, sizeof(buffer)) != 0)
+        {
+            // Convert wchar_t to std::string
+            std::wstring wideString(buffer);
+            std::string narrowString(wideString.begin(), wideString.end());
+            path = narrowString;
+        }
+    #else
+        if (GetModuleFileNameA(nullptr, buffer, sizeof(buffer)) != 0)
         {
             path = buffer;
         }
-        else
-        {
-            // failed to determine run path
-        }
+    #endif
+        // failed to determine run path
 #elif defined (__APPLE__)
         std::uint32_t size = sizeof(buffer);
         if(_NSGetExecutablePath(buffer, &size) == 0)


### PR DESCRIPTION
# Checklist

- The title and the commit message(s) are descriptive
- Small commits made to fix your PR have been squashed to avoid history pollution
- Tests have been added for new features or bug fixes
- API of new functions and classes are documented

# Description
The PR introduces `GetModuleFileNameW ` and `GetModuleFileNameA` which should be used instead of `GetModuleFileName` based on the type of buffer used.