### PR TITLE
Add missing includes to xbasic_fixed_string

### DIFF
--- a/include/xtl/xbasic_fixed_string.hpp
+++ b/include/xtl/xbasic_fixed_string.hpp
@@ -18,6 +18,8 @@
 #include <stdexcept>
 #include <string>
 #include <cassert>
+#include <algorithm>
+#include <type_traits>
 
 #ifdef __CLING__
 #include <nlohmann/json.hpp>


### PR DESCRIPTION
std::make_unsigned requires type_traits
std::copy_backwards requires algorithm
