### PR TITLE
Add missing includes to  xdynamic_bitset.hpp

### DIFF
--- a/include/xtl/xdynamic_bitset.hpp
+++ b/include/xtl/xdynamic_bitset.hpp
@@ -13,6 +13,10 @@
 #include <climits>
 #include <type_traits>
 #include <vector>
+#include <initializer_list>
+#include <iterator>
+#include <memory>
+#include <algorithm>
 
 #include "xclosure.hpp"
 #include "xspan.hpp"


### PR DESCRIPTION
`#include <initializer_list>` for std::initializer_list

`#include <memory>`  for std::allocator

`#include <algorithm>` for std::copy


