### PR TITLE
Lower the minimum CMake version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.16)
 project(xtl)
 
 set(XTL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)


### PR DESCRIPTION
# Description

Lower the minimum CMake version to allow installing on LTS versions of Ubuntu, since the actual CMake code doesn't require the new CMake version.

Arguably it would be better to change it to 3.22, since Ubuntu 20.04 is now not supported anymore, but since all the code works with 3.16, I decided to go with 3.16.
