### PR TITLE
Add xtl::select overload for complex values.

### DIFF
--- a/include/xtl/xcomplex.hpp
+++ b/include/xtl/xcomplex.hpp
@@ -106,6 +106,23 @@ namespace xtl
     template <class E, class R = void>
     using enable_scalar = std::enable_if_t<xtl::is_arithmetic<E>::value, R>;
 
+    /*************************
+     * select implementation *
+     *************************/
+
+    // Complex overload of xtl::select (see xfunctional.hpp, which covers
+    // scalars only): at least one of v1 / v2 is complex, the other may be a
+    // scalar.
+    template <class B, class T1, class T2,
+              XTL_REQUIRES(std::is_scalar<B>,
+                           std::disjunction<is_gen_complex<T1>, is_gen_complex<T2>>,
+                           std::disjunction<std::is_scalar<T1>, is_gen_complex<T1>>,
+                           std::disjunction<std::is_scalar<T2>, is_gen_complex<T2>>)>
+    inline std::common_type_t<T1, T2> select(const B& cond, const T1& v1, const T2& v2) noexcept
+    {
+        return cond ? v1 : v2;
+    }
+
     /*******************
      * common_xcomplex *
      *******************/

--- a/test/test_xcomplex.cpp
+++ b/test/test_xcomplex.cpp
@@ -328,5 +328,27 @@ namespace xtl
         EXPECT_COMPLEX_APPROX_EQ(b / x_closure, b / 5.0);
         EXPECT_COMPLEX_APPROX_EQ(x_closure / b, 5.0 / b);
     }
+
+    TEST(xcomplex, select)
+    {
+        std::complex<double> a(1., 2.);
+        std::complex<double> b(3., 4.);
+        EXPECT_EQ(select(true, a, b), a);
+        EXPECT_EQ(select(false, a, b), b);
+
+        // Mixed precision promotes to the common type.
+        std::complex<float> af(1.f, 2.f);
+        EXPECT_EQ(select(true, af, b), std::complex<double>(1., 2.));
+        EXPECT_EQ(select(false, af, b), b);
+
+        // Mixed real / complex.
+        EXPECT_EQ(select(true, 5., b), std::complex<double>(5., 0.));
+        EXPECT_EQ(select(false, 5., b), b);
+
+        xcomplex<double> xa(1., 2.);
+        xcomplex<double> xb(3., 4.);
+        EXPECT_EQ(select(true, xa, xb), xa);
+        EXPECT_EQ(select(false, xa, xb), xb);
+    }
 }
 


### PR DESCRIPTION
# Checklist

- [x] The title and the commit message(s) are descriptive
- [x] Small commits made to fix your PR have been squashed to avoid history pollution
- [x] Tests have been added for new features or bug fixes
- [ ] API of new functions and classes are documented

# Description

Implements `xtl::select` for complex operands, e.g. for downstream use:

```c++
xt::xarray<std::complex<double>> r = xt::where(cond, a, b);
```

Code implemented with AI assistance (claude code). PR is human-made.